### PR TITLE
Deployment state management during deployment fetching

### DIFF
--- a/deps/candid/rdmx6-jaaaa-aaaaa-aaadq-cai.did
+++ b/deps/candid/rdmx6-jaaaa-aaaaa-aaadq-cai.did
@@ -542,11 +542,6 @@ service : (opt InternetIdentityInit) -> {
     fetch_entries: () -> (vec BufferedArchiveEntry);
     acknowledge_entries: (sequence_number: nat64) -> ();
 
-    // Calls used for event stats housekeeping.
-    // Only callable by the canister itself.
-    prune_events_if_necessary: () -> ();
-    inject_prune_event: (timestamp: Timestamp) -> ();
-
     // V2 API
     // WARNING: The following methods are experimental and may change in the future.
 

--- a/deps/pulled.json
+++ b/deps/pulled.json
@@ -2,8 +2,8 @@
   "canisters": {
     "rdmx6-jaaaa-aaaaa-aaadq-cai": {
       "name": "internet_identity",
-      "wasm_hash": "764cff569a98a3c4d54cba6750fda63f554fc53e7d42a6365d9bdec3280d63c3",
-      "wasm_hash_download": "764cff569a98a3c4d54cba6750fda63f554fc53e7d42a6365d9bdec3280d63c3",
+      "wasm_hash": "01797eac7db02126e7cb507e2f3134e2d7b5154289808fdc2c8c03d1fc2dc60e",
+      "wasm_hash_download": "01797eac7db02126e7cb507e2f3134e2d7b5154289808fdc2c8c03d1fc2dc60e",
       "init_guide": "Use '(null)' for sensible defaults. See the candid interface for more details.",
       "init_arg": null,
       "candid_args": "(opt InternetIdentityInit)",

--- a/frontend/app/dashboard/new-deployment/page.tsx
+++ b/frontend/app/dashboard/new-deployment/page.tsx
@@ -19,7 +19,7 @@ import {displayE8sAsIcp, icpToE8s} from "@/helpers/ui";
 import {Spinner} from "@/components/spinner";
 import {NewDeploymentForm} from "@/components/new-deployment-form";
 import {transferE8sToBackend} from "@/services/backend";
-import {sendManifestToProviderFlow} from "@/services/deployment";
+import {confirmDeployment} from "@/services/deployment";
 
 const FETCH_DEPLOYMENT_PRICE_INTERVAL_MS = 30_000; // 30 seconds
 
@@ -163,7 +163,7 @@ export default function NewDeployment() {
             el.hasOwnProperty("DeploymentCreated")
           )!;
 
-          await sendManifestToProviderFlow(
+          await confirmDeployment(
             deploymentUpdate.update,
             deploymentCreatedState,
             tlsCertificateData!

--- a/frontend/app/dashboard/new-deployment/page.tsx
+++ b/frontend/app/dashboard/new-deployment/page.tsx
@@ -19,8 +19,7 @@ import {displayE8sAsIcp, icpToE8s} from "@/helpers/ui";
 import {Spinner} from "@/components/spinner";
 import {NewDeploymentForm} from "@/components/new-deployment-form";
 import {transferE8sToBackend} from "@/services/backend";
-import {extractDeploymentCreated} from "@/helpers/deployment";
-import {sendManifestToProvider} from "@/services/deployment";
+import {sendManifestToProviderFlow} from "@/services/deployment";
 
 const FETCH_DEPLOYMENT_PRICE_INTERVAL_MS = 30_000; // 30 seconds
 
@@ -160,21 +159,13 @@ export default function NewDeployment() {
           // closeWs();
           // return;
 
-          const {manifest_sorted_json, dseq} = extractDeploymentCreated(
-            deploymentSteps.find((el) =>
-              el.hasOwnProperty("DeploymentCreated")
-            )!
-          );
-          const {provider_url} = deploymentUpdate.update.LeaseCreated;
+          const deploymentCreatedState = deploymentSteps.find((el) =>
+            el.hasOwnProperty("DeploymentCreated")
+          )!;
 
-          const manifestUrl = new URL(
-            `/deployment/${dseq}/manifest`,
-            provider_url
-          );
-
-          await sendManifestToProvider(
-            manifestUrl.toString(),
-            manifest_sorted_json,
+          await sendManifestToProviderFlow(
+            deploymentUpdate.update,
+            deploymentCreatedState,
             tlsCertificateData!
           );
 

--- a/frontend/app/dashboard/new-deployment/page.tsx
+++ b/frontend/app/dashboard/new-deployment/page.tsx
@@ -1,33 +1,33 @@
 "use client";
 
-import { BackButton } from "@/components/back-button";
-import { useToast } from "@/components/ui/use-toast";
-import { useDeploymentContext } from "@/contexts/DeploymentContext";
+import {BackButton} from "@/components/back-button";
+import {useToast} from "@/components/ui/use-toast";
+import {useDeploymentContext} from "@/contexts/DeploymentContext";
 import {
   type OnWsErrorCallback,
   type OnWsMessageCallback,
   type OnWsOpenCallback,
   useIcContext,
 } from "@/contexts/IcContext";
-import type { DeploymentParams, DeploymentState } from "@/declarations/backend.did";
-import { extractDeploymentCreated } from "@/helpers/deployment";
-import { extractOk } from "@/helpers/result";
-import { sendManifestToProvider } from "@/services/deployment";
-import { useRouter } from "next/navigation";
-import { useCallback, useEffect, useMemo, useState } from "react";
-import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
-import { AlertCircle } from "lucide-react";
-import { displayE8sAsIcp, icpToE8s } from "@/helpers/ui";
-import { Spinner } from "@/components/spinner";
-import { NewDeploymentForm } from "@/components/new-deployment-form";
-import { transferE8sToBackend } from "@/services/backend";
+import type {DeploymentParams, DeploymentState} from "@/declarations/backend.did";
+import {extractOk} from "@/helpers/result";
+import {useRouter} from "next/navigation";
+import {useCallback, useEffect, useMemo, useState} from "react";
+import {Alert, AlertDescription, AlertTitle} from "@/components/ui/alert";
+import {AlertCircle} from "lucide-react";
+import {displayE8sAsIcp, icpToE8s} from "@/helpers/ui";
+import {Spinner} from "@/components/spinner";
+import {NewDeploymentForm} from "@/components/new-deployment-form";
+import {transferE8sToBackend} from "@/services/backend";
+import {extractDeploymentCreated} from "@/helpers/deployment";
+import {sendManifestToProvider} from "@/services/deployment";
 
 const FETCH_DEPLOYMENT_PRICE_INTERVAL_MS = 30_000; // 30 seconds
 
 export default function NewDeployment() {
   const router = useRouter();
-  const { backendActor, openWs, closeWs, setWsCallbacks, ledgerCanister, ledgerData, refreshLedgerData } = useIcContext();
-  const { tlsCertificateData, loadOrCreateCertificate, fetchDeployments } =
+  const {backendActor, openWs, closeWs, setWsCallbacks, ledgerCanister, ledgerData, refreshLedgerData} = useIcContext();
+  const {tlsCertificateData, loadOrCreateCertificate, fetchDeployments} =
     useDeploymentContext();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isDeploying, setIsDeploying] = useState(false);
@@ -38,12 +38,12 @@ export default function NewDeployment() {
   const [deploymentE8sPrice, setDeploymentE8sPrice] = useState<bigint | null>(null);
   const [fetchDeploymentPriceInterval, setFetchDeploymentPriceInterval] = useState<NodeJS.Timeout | null>(null);
   const userHasEnoughBalance = useMemo(() =>
-    ledgerData.balanceE8s !== null && deploymentE8sPrice !== null && ledgerData.balanceE8s > deploymentE8sPrice,
+      ledgerData.balanceE8s !== null && deploymentE8sPrice !== null && ledgerData.balanceE8s > deploymentE8sPrice,
     [ledgerData.balanceE8s, deploymentE8sPrice]
   );
   const [paymentStatus, setPaymentStatus] = useState<string | null>(null);
   const [deploymentParams, setDeploymentParams] = useState<DeploymentParams | null>(null);
-  const { toast } = useToast();
+  const {toast} = useToast();
 
   const toastError = useCallback(
     (message: string) => {
@@ -113,7 +113,7 @@ export default function NewDeployment() {
       const res = await backendActor.create_deployment(deploymentParams);
       const deploymentId = extractOk(res);
       console.log("deployment id", deploymentId);
-      setDeploymentSteps([{ Initialized: null }]);
+      setDeploymentSteps([{Initialized: null}]);
     };
 
     setIsDeploying(true);
@@ -157,12 +157,15 @@ export default function NewDeployment() {
 
       try {
         if ("LeaseCreated" in deploymentUpdate.update) {
-          const { manifest_sorted_json, dseq } = extractDeploymentCreated(
+          // closeWs();
+          // return;
+
+          const {manifest_sorted_json, dseq} = extractDeploymentCreated(
             deploymentSteps.find((el) =>
               el.hasOwnProperty("DeploymentCreated")
             )!
           );
-          const { provider_url } = deploymentUpdate.update.LeaseCreated;
+          const {provider_url} = deploymentUpdate.update.LeaseCreated;
 
           const manifestUrl = new URL(
             `/deployment/${dseq}/manifest`,
@@ -350,7 +353,7 @@ export default function NewDeployment() {
   return (
     <div className="flex-1 space-y-4 p-8 pt-6">
       <div className="flex items-center justify-start">
-        <BackButton />
+        <BackButton/>
         <h2 className="ml-4 text-3xl font-bold tracking-tight">
           Create Deployment
         </h2>
@@ -369,13 +372,13 @@ export default function NewDeployment() {
               Price (est.):
             </h5>
             {deploymentE8sPrice !== null ? (
-              <pre>~{displayE8sAsIcp(deploymentE8sPrice, { maximumFractionDigits: 6 })}</pre>
+              <pre>~{displayE8sAsIcp(deploymentE8sPrice, {maximumFractionDigits: 6})}</pre>
             ) : (
-              <Spinner />
+              <Spinner/>
             )}
             {(!(isSubmitting || isDeploying) && (deploymentE8sPrice !== null) && !userHasEnoughBalance) && (
               <Alert variant="destructive">
-                <AlertCircle className="h-4 w-4" />
+                <AlertCircle className="h-4 w-4"/>
                 <AlertTitle>Insufficient balance</AlertTitle>
                 <AlertDescription>
                   <p>Please top up your account.</p>
@@ -408,13 +411,13 @@ export default function NewDeployment() {
                       {idx + 1}. {el}
                     </p>
                   ))}
-                {isDeploying && <Spinner />}
+                {isDeploying && <Spinner/>}
               </div>
             </div>
           )}
           {Boolean(deploymentError) && (
             <Alert variant="destructive">
-              <AlertCircle className="h-4 w-4" />
+              <AlertCircle className="h-4 w-4"/>
               <AlertTitle>Deployment Error</AlertTitle>
               <AlertDescription>
                 <p>{deploymentError}</p>

--- a/frontend/app/dashboard/new-deployment/page.tsx
+++ b/frontend/app/dashboard/new-deployment/page.tsx
@@ -19,7 +19,7 @@ import {displayE8sAsIcp, icpToE8s} from "@/helpers/ui";
 import {Spinner} from "@/components/spinner";
 import {NewDeploymentForm} from "@/components/new-deployment-form";
 import {transferE8sToBackend} from "@/services/backend";
-import {confirmDeployment} from "@/services/deployment";
+import {confirmDeployment, updateDeploymentState} from "@/services/deployment";
 
 const FETCH_DEPLOYMENT_PRICE_INTERVAL_MS = 30_000; // 30 seconds
 
@@ -156,9 +156,6 @@ export default function NewDeployment() {
 
       try {
         if ("LeaseCreated" in deploymentUpdate.update) {
-          // closeWs();
-          // return;
-
           const deploymentCreatedState = deploymentSteps.find((el) =>
             el.hasOwnProperty("DeploymentCreated")
           )!;
@@ -183,12 +180,7 @@ export default function NewDeployment() {
 
           setDeploymentSteps((prev) => [...prev, stepFailed]);
 
-          extractOk(
-            await backendActor!.update_deployment_state(
-              deploymentUpdate.id,
-              stepFailed
-            )
-          );
+          await updateDeploymentState(backendActor!, deploymentUpdate.id, stepFailed);
         } catch (e) {
           console.error("Failed to update deployment:", e);
         }
@@ -207,12 +199,8 @@ export default function NewDeployment() {
             Active: null,
           };
           setDeploymentSteps((prev) => [...prev, stepActive]);
-          extractOk(
-            await backendActor!.update_deployment_state(
-              deploymentUpdate.id,
-              stepActive
-            )
-          );
+
+          await updateDeploymentState(backendActor!, deploymentUpdate.id, stepActive);
 
           await fetchDeployments(backendActor!);
 

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -36,6 +36,7 @@ import {DeploymentTier} from "@/types/deployment";
 import {ChevronsUpDown} from "lucide-react";
 import {useRouter} from "next/navigation";
 import {useCallback, useEffect, useState} from "react";
+import {extractOk} from "@/helpers/result";
 
 export default function Dashboard() {
   const router = useRouter();
@@ -145,6 +146,17 @@ export default function Dashboard() {
             manifestUrl.toString(),
             manifest_sorted_json,
             cert!
+          );
+
+          const stepActive = {
+            Active: null,
+          };
+
+          extractOk(
+            await backendActor!.update_deployment_state(
+              deployment.id,
+              stepActive
+            )
           );
         } catch (e) {
           console.error(e);

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -31,7 +31,7 @@ import {
   isDeploymentFailed,
 } from "@/helpers/deployment";
 import {displayIcp} from "@/helpers/ui";
-import {queryLeaseStatus, sendManifestToProviderFlow} from "@/services/deployment";
+import {confirmDeployment, queryLeaseStatus} from "@/services/deployment";
 import {DeploymentTier} from "@/types/deployment";
 import {ChevronsUpDown} from "lucide-react";
 import {useRouter} from "next/navigation";
@@ -131,7 +131,7 @@ export default function Dashboard() {
         try {
           const cert = await loadOrCreateCertificate(backendActor!);
 
-          await sendManifestToProviderFlow(
+          await confirmDeployment(
             lastState,
             deploymentCreatedState,
             cert!
@@ -147,8 +147,10 @@ export default function Dashboard() {
               stepActive
             )
           );
+
+          await fetchDeployments(backendActor!);
         } catch (e) {
-          console.error(e);
+          console.error("Failed to update deployment:", e);
         }
       }
     }

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -1,11 +1,11 @@
 "use client";
 
 import Tier from "@/components/Tier";
-import {LoadingButton} from "@/components/loading-button";
-import {Spinner} from "@/components/spinner";
-import {Button} from "@/components/ui/button";
-import {Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle,} from "@/components/ui/card";
-import {Collapsible, CollapsibleContent, CollapsibleTrigger,} from "@/components/ui/collapsible";
+import { LoadingButton } from "@/components/loading-button";
+import { Spinner } from "@/components/spinner";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle, } from "@/components/ui/card";
+import { Collapsible, CollapsibleContent, CollapsibleTrigger, } from "@/components/ui/collapsible";
 import {
   Dialog,
   DialogContent,
@@ -15,10 +15,10 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog";
-import {useToast} from "@/components/ui/use-toast";
-import {useDeploymentContext} from "@/contexts/DeploymentContext";
-import {useIcContext} from "@/contexts/IcContext";
-import {type Deployment} from "@/declarations/backend.did";
+import { useToast } from "@/components/ui/use-toast";
+import { useDeploymentContext } from "@/contexts/DeploymentContext";
+import { useIcContext } from "@/contexts/IcContext";
+import { type Deployment } from "@/declarations/backend.did";
 import {
   extractDeploymentCreated,
   extractLeaseCreated,
@@ -30,17 +30,17 @@ import {
   isDeploymentClosed,
   isDeploymentFailed,
 } from "@/helpers/deployment";
-import {displayIcp} from "@/helpers/ui";
-import {confirmDeployment, queryLeaseStatus, updateDeploymentState} from "@/services/deployment";
-import {DeploymentTier} from "@/types/deployment";
-import {ChevronsUpDown} from "lucide-react";
-import {useRouter} from "next/navigation";
-import {useCallback, useEffect, useState} from "react";
+import { displayIcp } from "@/helpers/ui";
+import { queryLeaseStatus } from "@/services/deployment";
+import { DeploymentTier } from "@/types/deployment";
+import { ChevronsUpDown } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useCallback, useEffect, useState } from "react";
 
 export default function Dashboard() {
   const router = useRouter();
-  const {isLoggedIn, backendActor} = useIcContext();
-  const {deployments, fetchDeployments, loadOrCreateCertificate} =
+  const { isLoggedIn, backendActor } = useIcContext();
+  const { deployments, fetchDeployments, loadOrCreateCertificate } =
     useDeploymentContext();
   const [isClosingDeployment, setIsClosingDeployment] = useState(false);
   const [dialogDeploymentId, setDialogDeploymentId] = useState<string>();
@@ -48,7 +48,7 @@ export default function Dashboard() {
   const [isFetchingStatus, setIsFetchingStatus] = useState(false);
   const [leaseStatusData, setLeaseStatusData] =
     useState<Record<string, unknown>>();
-  const {toast} = useToast();
+  const { toast } = useToast();
 
   const handleNewDeployment = useCallback(async () => {
     router.push("/dashboard/new-deployment");
@@ -81,10 +81,10 @@ export default function Dashboard() {
       try {
         const certData = await loadOrCreateCertificate(backendActor!);
         const updates = deployment.state_history.map(([_, d]) => d);
-        const {dseq} = extractDeploymentCreated(
+        const { dseq } = extractDeploymentCreated(
           updates.find((el) => el.hasOwnProperty("DeploymentCreated"))!
         );
-        const {provider_url} = extractLeaseCreated(
+        const { provider_url } = extractLeaseCreated(
           updates.find((el) => el.hasOwnProperty("LeaseCreated"))!
         );
 
@@ -117,60 +117,6 @@ export default function Dashboard() {
       fetchDeployments(backendActor);
     }
   }, [isLoggedIn, fetchDeployments, backendActor]);
-
-  useEffect(() => {
-    checkDeploymentState();
-  }, [deployments]);
-
-  const checkDeploymentState = useCallback(async () => {
-    for (const deployment of deployments) {
-      const lastState = deployment.deployment.state_history[deployment.deployment.state_history.length - 1][1];
-      const deploymentCreatedState = deployment.deployment.state_history.find(([_, state]) => "DeploymentCreated" in state)![1];
-      if ("LeaseCreated" in lastState) {
-        let leaseCreated = false;
-
-        try {
-          const cert = await loadOrCreateCertificate(backendActor!);
-
-          await confirmDeployment(
-            lastState,
-            deploymentCreatedState,
-            cert!
-          );
-
-          leaseCreated = true;
-        } catch (e) {
-          console.error("Failed to update deployment:", e);
-
-          try {
-            const stepFailed = {
-              FailedOnClient: {
-                reason: JSON.stringify(e),
-              },
-            };
-            await updateDeploymentState(backendActor!, deployment.id, stepFailed);
-          } catch (e) {
-            console.error("Failed to update deployment:", e);
-          }
-        }
-
-        try {
-          if (leaseCreated) {
-
-            const stepActive = {
-              Active: null,
-            };
-
-            await updateDeploymentState(backendActor!, deployment.id, stepActive);
-
-            await fetchDeployments(backendActor!);
-          }
-        } catch (e) {
-          console.error("Failed to complete deployment:", e);
-        }
-      }
-    }
-  }, [backendActor, deployments, loadOrCreateCertificate]);
 
   return (
     <div className="flex-1 space-y-4 p-8 pt-6">
@@ -208,17 +154,17 @@ export default function Dashboard() {
                   Tier:
                   {/* TODO: display the actual deployment tier */}
                   <div className="border rounded-md px-3 py-2">
-                    <Tier tier={DeploymentTier.SMALL}/>
+                    <Tier tier={DeploymentTier.SMALL} />
                   </div>
                 </div>
                 <div className="flex flex-row gap-1">
                   Price:
-                  <pre>{displayIcp(el.deployment.icp_price, {maximumFractionDigits: 6})}</pre>
+                  <pre>{displayIcp(el.deployment.icp_price, { maximumFractionDigits: 6 })}</pre>
                 </div>
                 <Collapsible>
                   <CollapsibleTrigger className="flex items-center gap-4 w-full mt-4">
                     Status history
-                    <ChevronsUpDown className="h-4 w-4"/>
+                    <ChevronsUpDown className="h-4 w-4" />
                   </CollapsibleTrigger>
                   <CollapsibleContent className="flex flex-col gap-1">
                     {el.deployment.state_history.map((item, i) => (
@@ -254,7 +200,7 @@ export default function Dashboard() {
                             <DialogTitle>Deployment status</DialogTitle>
                             <DialogDescription>
                               {isFetchingStatus ? (
-                                <Spinner/>
+                                <Spinner />
                               ) : (
                                 Boolean(leaseStatusData) && (
                                   <span className="font-mono">
@@ -282,9 +228,9 @@ export default function Dashboard() {
                         <DialogTitle>Are you sure?</DialogTitle>
                         <DialogDescription>
                           Deployment id to close:
-                          <br/>
+                          <br />
                           <span className="font-mono text-nowrap">{el.id}</span>
-                          <br/>
+                          <br />
                           <b>This action cannot be undone.</b>
                         </DialogDescription>
                       </DialogHeader>

--- a/frontend/services/deployment.ts
+++ b/frontend/services/deployment.ts
@@ -2,6 +2,8 @@ import {X509CertificateData} from "@/lib/certificate";
 import {wait} from "@/helpers/timer";
 import {DeploymentState, MTlsCertificateData} from "@/declarations/backend.did";
 import {extractDeploymentCreated} from "@/helpers/deployment";
+import {BackendActor} from "@/services/backend";
+import {extractOk} from "@/helpers/result";
 
 const PROVIDER_PROXY_URL = "https://akash-provider-proxy.omnia-network.com/";
 
@@ -102,4 +104,14 @@ export const confirmDeployment = async (deploymentState: DeploymentState, deploy
     console.error("Failed to send manifest to provider", e);
     throw e;
   }
+}
+
+export const updateDeploymentState = async (backendActor: BackendActor, deploymentId: string, step: DeploymentState) => {
+  try {
+    extractOk(await backendActor.update_deployment_state(deploymentId, step));
+  } catch (e) {
+    console.error("Failed to update deployment state", e);
+    throw e;
+  }
+
 }

--- a/frontend/services/deployment.ts
+++ b/frontend/services/deployment.ts
@@ -1,9 +1,9 @@
-import {X509CertificateData} from "@/lib/certificate";
-import {wait} from "@/helpers/timer";
-import {DeploymentState, MTlsCertificateData} from "@/declarations/backend.did";
-import {extractDeploymentCreated} from "@/helpers/deployment";
-import {BackendActor} from "@/services/backend";
-import {extractOk} from "@/helpers/result";
+import { X509CertificateData } from "@/lib/certificate";
+import { wait } from "@/helpers/timer";
+import { DeploymentState, MTlsCertificateData } from "@/declarations/backend.did";
+import { extractDeploymentCreated } from "@/helpers/deployment";
+import { BackendActor } from "@/services/backend";
+import { extractOk } from "@/helpers/result";
 
 const PROVIDER_PROXY_URL = "https://akash-provider-proxy.omnia-network.com/";
 
@@ -82,9 +82,9 @@ export const queryLeaseStatus = async (queryLeaseUrl: string, certData: X509Cert
 export const confirmDeployment = async (deploymentState: DeploymentState, deploymentCreatedState: DeploymentState, cert: MTlsCertificateData) => {
   try {
     if ("LeaseCreated" in deploymentState) {
-      const {manifest_sorted_json, dseq} = extractDeploymentCreated(deploymentCreatedState);
+      const { manifest_sorted_json, dseq } = extractDeploymentCreated(deploymentCreatedState);
 
-      const {provider_url} = deploymentState.LeaseCreated;
+      const { provider_url } = deploymentState.LeaseCreated;
 
       const manifestUrl = new URL(
         `/deployment/${dseq}/manifest`,
@@ -115,3 +115,11 @@ export const updateDeploymentState = async (backendActor: BackendActor, deployme
   }
 
 }
+
+export const completeDeployment = async (backendActor: BackendActor, deploymentId: string) => {
+  const stepActive = {
+    Active: null,
+  };
+
+  await updateDeploymentState(backendActor!, deploymentId, stepActive);
+};

--- a/frontend/services/deployment.ts
+++ b/frontend/services/deployment.ts
@@ -77,7 +77,7 @@ export const queryLeaseStatus = async (queryLeaseUrl: string, certData: X509Cert
   return await res.json();
 };
 
-export const sendManifestToProviderFlow = async (deploymentState: DeploymentState, deploymentCreatedState: DeploymentState, cert: MTlsCertificateData) => {
+export const confirmDeployment = async (deploymentState: DeploymentState, deploymentCreatedState: DeploymentState, cert: MTlsCertificateData) => {
   try {
     if ("LeaseCreated" in deploymentState) {
       const {manifest_sorted_json, dseq} = extractDeploymentCreated(deploymentCreatedState);
@@ -94,6 +94,7 @@ export const sendManifestToProviderFlow = async (deploymentState: DeploymentStat
         manifest_sorted_json,
         cert!
       );
+
     } else {
       throw new Error("Deployment state is not in LeaseCreated state");
     }


### PR DESCRIPTION
Within the dashboard, when deployments are retrieved, if there is one with the LeaseCreated status, the frontend attempts to sendManifest to the akash network and update the deployment status of the canister.
This is necessary to solve the problem of the websocket being closed during deployment.